### PR TITLE
New lint step that guards against presence of "path" inputs

### DIFF
--- a/.github/workflows/_internal_lint_failure.yml
+++ b/.github/workflows/_internal_lint_failure.yml
@@ -1,0 +1,39 @@
+# This workflow calls the reusable test workflow and ensures that the
+# tests do not pass.
+#
+# Please don't use this as a reusable workflow, because it is very
+# much not.
+
+name: Internal job invocation that expects a lint failure result
+on:
+  workflow_call:
+    inputs:
+      root:
+        description: "Directory containing the go.mod of the codebase under test"
+        type: string
+        default: "."
+      failing_job:
+        description: "Job that is intended to fail"
+        type: "string"
+
+jobs:
+  lints:
+    uses: "./.github/workflows/lints.yml"
+    with:
+      root: ${{inputs.root}}
+      _internal_continue_on_error: ${{inputs.failing_job}}
+
+  expect_lint_failure:
+    runs-on: ubuntu-latest
+    needs: lints
+    steps:
+      - name: transform expected failure
+        id: expected_failure
+        env:
+          NEEDS_JSON: ${{toJSON(needs)}}
+          NEEDS_OUTPUT: ${{fromJSON(needs.lints.outputs._internal_lint_result)[inputs.failing_job]}}
+        run: >
+          echo "status=$NEEDS_OUTPUT" | tee -a $GITHUB_OUTPUT
+      - name: expect failure
+        run: exit 1
+        if: steps.expected_failure.outputs.status != 'failure'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,20 @@
+name: "Tests for this repo"
+on:
+  workflow_call:
+  pull_request:
+
+jobs:
+  success_build:
+    uses: "./.github/workflows/build.yml"
+    with:
+      root: "./tests/success"
+
+  success_lint:
+    uses: "./.github/workflows/lints.yml"
+    with:
+      root: "./tests/success"
+
+  success_test:
+    uses: "./.github/workflows/tests.yml"
+    with:
+      root: "./tests/success"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,3 +18,9 @@ jobs:
     uses: "./.github/workflows/tests.yml"
     with:
       root: "./tests/success"
+
+  fail_on_path_inputs:
+    uses: "./.github/workflows/_internal_lint_failure.yml"
+    with:
+      root: "./tests/fail-safety-check"
+      failing_job: "flake_safety"

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -7,9 +7,22 @@ on:
         description: "Directory that the nix flake resides in."
         default: "."
 
+      # Used for testing this repo:
+      _internal_continue_on_error:
+        description: "Name of the job to set continue-on-error on; pass this only in the tests _inside this repo_. Otherwise your workflow run will pass when it shouldn't."
+        type: string
+        default: ""
+    outputs:
+      _internal_lint_result:
+        description: "Result of the build job"
+        value: '{"fmt": ${{toJSON(jobs.fmt.outputs.result)}}, "flake_safety": ${{toJSON(jobs.flake_safety.outputs.result)}}}'
+
 jobs:
   fmt:
     name: "nix fmt ${{inputs.root}}"
+    continue-on-error: ${{inputs._internal_continue_on_error == 'fmt'}}
+    outputs:
+      result: ${{steps.result.outcome}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,9 +31,13 @@ jobs:
       - run: cd ${{ inputs.root }} && nix fmt
       - name: Show unformatted files, if any
         run: git diff --exit-code
+        id: result
 
   flake_safety:
     name: "nix flake safety"
+    continue-on-error: ${{inputs._internal_continue_on_error == 'flake_safety'}}
+    outputs:
+      result: ${{steps.result.outcome}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,6 +53,7 @@ jobs:
         id: path_nodes
       - name: fail if bad lock entries are present
         if: ${{ steps.path_nodes.outputs.entries != '' }}
+        id: result
         run: |
           echo "The following lock entries are locked as 'path' types, causing the flake to probably be un-usable on machines that don't have that path present:"
           echo "${{steps.path_nodes.outputs.entries}}"

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -26,14 +26,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v25
       - name: inputs with unreproducible lock entries
-        run: nix flake metadata --json | jq -r '.locks.nodes | map_values(select(.locked.type == "path")) | keys[]'
+        run: |
+          {
+            echo "entries<<EOF"
+            nix flake metadata --json | jq -r '.locks.nodes | map_values(select(.locked.type == "path")) | keys[]'
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
         working-directory: ${{ inputs.root }}
         id: path_nodes
       - name: fail if bad lock entries are present
-        if: ${{ steps.path_nodes.outputs != '' }}
+        if: ${{ steps.path_nodes.outputs.entries != '' }}
         run: |
           echo "The following lock entries are locked as 'path' types, causing the flake to probably be un-usable on machines that don't have that path present:"
-          echo "${{steps.path_nodes.outputs}}"
+          echo "${{steps.path_nodes.outputs.entries}}"
           echo ""
           echo "To remedy, make sure that all of these entries have corresponding inputs in the flake.nix."
           exit 1

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -18,3 +18,22 @@ jobs:
       - run: cd ${{ inputs.root }} && nix fmt
       - name: Show unformatted files, if any
         run: git diff --exit-code
+
+  flake_safety:
+    name: "nix flake safety"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v25
+      - name: inputs with unreproducible lock entries
+        run: nix flake metadata --json | jq -r '.locks.nodes | map_values(select(.locked.type == "path")) | keys[]'
+        working-directory: ${{ inputs.root }}
+        id: path_nodes
+      - name: fail if bad lock entries are present
+        if: ${{ steps.path_nodes.outputs != '' }}
+        run: |
+          echo "The following lock entries are locked as 'path' types, causing the flake to probably be un-usable on machines that don't have that path present:"
+          echo "${{steps.path_nodes.outputs}}"
+          echo ""
+          echo "To remedy, make sure that all of these entries have corresponding inputs in the flake.nix."
+          exit 1

--- a/tests/fail-safety-check/flake.lock
+++ b/tests/fail-safety-check/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733229606,
+        "narHash": "sha256-FLYY5M0rpa5C2QAE3CKLYAM6TwbKicdRK6qNrSHlNrE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "some_input": "some_input"
+      }
+    },
+    "some_input": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-rAw0RmkZy1ZoQihFE+ur8kY+pAu/86Sjb5e28tDshF4=",
+        "path": "./some_input",
+        "type": "path"
+      },
+      "original": {
+        "path": "./some_input",
+        "type": "path"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fail-safety-check/flake.nix
+++ b/tests/fail-safety-check/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "a flake that should successfully pass the baseline-nix tests";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    some_input = {
+      url = "path:./some_input";
+      flake = false;
+    };
+  };
+
+  outputs = {nixpkgs, ...}: let
+    systems = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "riscv64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    eachSystem = f:
+      nixpkgs.lib.genAttrs systems (
+        system:
+          f rec {
+            inherit system;
+            pkgs = nixpkgs.legacyPackages.${system};
+          }
+      );
+  in {
+    formatter = eachSystem ({pkgs, ...}: pkgs.alejandra);
+    packages = eachSystem ({pkgs, ...}: {default = pkgs.hello;});
+  };
+}

--- a/tests/success/flake.lock
+++ b/tests/success/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733229606,
+        "narHash": "sha256-FLYY5M0rpa5C2QAE3CKLYAM6TwbKicdRK6qNrSHlNrE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/success/flake.nix
+++ b/tests/success/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "a flake that should successfully pass the baseline-nix tests";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = {nixpkgs, ...}: let
+    systems = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "riscv64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    eachSystem = f:
+      nixpkgs.lib.genAttrs systems (
+        system:
+          f rec {
+            inherit system;
+            pkgs = nixpkgs.legacyPackages.${system};
+          }
+      );
+  in {
+    formatter = eachSystem ({pkgs, ...}: pkgs.alejandra);
+    packages = eachSystem ({pkgs, ...}: {default = pkgs.hello;});
+  };
+}


### PR DESCRIPTION
These usually happen when the flake is written hastily, e.g. when an input is omitted from the list & nix uses the machine-local flake registry. Instead, we want to force code to explicitly list flake inputs in flake.nix, both for overrideability but also reproducibility on other machines.