### PR TITLE
Improve path lint

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,6 @@
 name: "Tests for this repo"
 on:
   workflow_call:
-  pull_request:
 
 jobs:
   success_build:

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           {
             echo "entries<<EOF"
-            nix flake metadata --json | jq -r '.locks.nodes | map_values(select(.locked.type == "path")) | keys[]'
+            nix flake metadata --json | jq -r '.locks.nodes | map_values(select(.locked.type == "path" and .original.type == "indirect")) | keys[]'
             echo EOF
           } >> "$GITHUB_OUTPUT"
         working-directory: ${{ inputs.root }}

--- a/tests/fail-safety-check/flake.lock
+++ b/tests/fail-safety-check/flake.lock
@@ -2,18 +2,15 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733229606,
-        "narHash": "sha256-FLYY5M0rpa5C2QAE3CKLYAM6TwbKicdRK6qNrSHlNrE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
-        "type": "github"
+        "lastModified": 1731890469,
+        "narHash": "sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs=",
+        "path": "/nix/store/n1g84klfb0h3bpwyvc59lcy5ca58h36w-source",
+        "rev": "5083ec887760adfe12af64830a66807423a859a7",
+        "type": "path"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "type": "indirect"
       }
     },
     "root": {

--- a/tests/fail-safety-check/flake.nix
+++ b/tests/fail-safety-check/flake.nix
@@ -2,7 +2,6 @@
   description = "a flake that should successfully pass the baseline-nix tests";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     some_input = {
       url = "path:./some_input";
       flake = false;


### PR DESCRIPTION
This should ensure only "indirect" entries with stored paths get picked up by the lint, which seems to be exactly the kind of lock entry that gets made for flake-registry usages.