### PR TITLE
Add github job ID to the cache primary key

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -29,6 +29,6 @@ runs:
         lix_conf: ${{ inputs.extra_nix_config }}
     - uses: nix-community/cache-nix-action@v6
       with:
-        primary-key: nix-${{ runner.os }}-${{ hashFiles(format('{0}/**/*.nix', inputs.root), format('{0}/**/flake.lock', inputs.root)) }}
-        restore-prefixes-first-match: nix-${{ runner.os }}-
+        primary-key: nix-${{ runner.os }}-${{ hashFiles(format('{0}/**/*.nix', inputs.root), format('{0}/**/flake.lock', inputs.root)) }}-${{ github.job }}
+        restore-prefixes-first-match: nix-${{ runner.os }}
         gc-max-store-size-linux: 1G


### PR DESCRIPTION
This should ensure that fast-running jobs don't squat the cache IDs such that longer-running jobs (which generate more nix store entries) don't get to save their stuff.